### PR TITLE
Refactor mockup generation output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,24 +64,38 @@ MockupGenerator is a Ruby tool that generates realistic mockups from templates, 
 require 'rmagick'
 require './mockup_generator'
 
-# Paths to the files
 template = "/path/to/template.jpg"
 mask = "/path/to/mask.png"
 artwork = "/path/to/artwork.png"
 
-# Initialize the mockup generator
+# By default the generator writes the final composite to `mockup.png`
+# in the current working directory.
 generator = MockupGenerator.new(template, mask, artwork)
+image = generator.generate
 
-# Generate the mockup
-generator.generate
+puts "Final mockup stored at: #{image.filename}" # => ".../mockup.png"
+
+# You can customise the output directory, base filename and whether the
+# intermediate maps are persisted by passing keywords either to `new` or `generate`.
+custom_generator = MockupGenerator.new(
+  template,
+  mask,
+  artwork,
+  output_dir: "/path/to/output",
+  basename: "summer_campaign",
+  save_intermediate: true
+)
+
+# Keyword arguments on `generate` override the defaults set on initialization.
+custom_image = custom_generator.generate(save_intermediate: false)
+
+puts custom_image.filename # => "/path/to/output/summer_campaign.png"
 ```
 
-The generated files will be saved in the current directory:
-
-- `adjustment_map.jpg`
-- `displacement_map.png`
-- `lighting_map.png`
-- `mockup.png`
+When `save_intermediate` is `true`, the adjustment, displacement and lighting maps
+are written alongside the final mockup using the provided base name (for example,
+`summer_campaign_adjustment_map.jpg`). If it is `false`—the default—only the final
+composite image is saved.
 
 ## Examples
 

--- a/mockup_generator.rb
+++ b/mockup_generator.rb
@@ -1,17 +1,43 @@
 require 'rmagick'
+require 'fileutils'
 
 class MockupGenerator
-  def initialize(template_path, mask_path, artwork_path)
+  def initialize(template_path, mask_path, artwork_path, output_dir: nil, basename: nil, save_intermediate: false)
     @template = Magick::Image.read(template_path).first
     @mask = Magick::Image.read(mask_path).first
     @artwork = Magick::Image.read(artwork_path).first
+    @output_dir = output_dir || Dir.pwd
+    @basename = basename || 'mockup'
+    @save_intermediate = save_intermediate
   end
 
-  def generate
-    generate_adjustment_map
-    generate_displacement_map
-    generate_lighting_map
-    generate_final_mockup
+  def generate(output_dir: nil, basename: nil, save_intermediate: nil)
+    effective_output_dir = output_dir || @output_dir
+    effective_basename = basename || @basename
+    effective_save_intermediate = save_intermediate.nil? ? @save_intermediate : save_intermediate
+
+    FileUtils.mkdir_p(effective_output_dir) unless Dir.exist?(effective_output_dir)
+
+    adjustment_map = generate_adjustment_map
+    displacement_map = generate_displacement_map
+    lighting_map = generate_lighting_map
+
+    if effective_save_intermediate
+      adjustment_map.write(File.join(effective_output_dir, "#{effective_basename}_adjustment_map.jpg"))
+      displacement_map.write(File.join(effective_output_dir, "#{effective_basename}_displacement_map.png"))
+      lighting_map.write(File.join(effective_output_dir, "#{effective_basename}_lighting_map.png"))
+    end
+
+    final_image = generate_final_mockup(
+      adjustment_map: adjustment_map,
+      displacement_map: displacement_map,
+      lighting_map: lighting_map
+    )
+
+    final_path = File.join(effective_output_dir, "#{effective_basename}.png")
+    final_image.write(final_path)
+
+    final_image
   end
 
   private
@@ -55,7 +81,7 @@ class MockupGenerator
   def generate_adjustment_map
     grayscale_mask = @mask.quantize(256, Magick::GRAYColorspace)
     adjustment_map = @template.composite(grayscale_mask, Magick::CenterGravity, Magick::DivideSrcCompositeOp)
-    adjustment_map.write('adjustment_map.jpg')
+    adjustment_map
   end
 
   def generate_displacement_map
@@ -74,8 +100,8 @@ class MockupGenerator
     displacement_map.alpha(Magick::RemoveAlphaChannel)
   
     displacement_map = displacement_map.blur_image(0, 10)
-  
-    displacement_map.write('displacement_map.png')
+
+    displacement_map
   end
 
   def generate_lighting_map
@@ -88,7 +114,7 @@ class MockupGenerator
     
     grey_image = Magick::Image.new(lighting_map.columns, lighting_map.rows) { |img| img.background_color = 'grey50' }
     lighting_map = lighting_map.composite(grey_image, Magick::CenterGravity, Magick::LightenCompositeOp)
-    lighting_map.write('lighting_map.png')
+    lighting_map
   end
 
   def get_mask_bounding_box(mask)
@@ -102,7 +128,7 @@ class MockupGenerator
     return [x_offset, y_offset, width, height]
   end
 
-  def generate_final_mockup
+  def generate_final_mockup(adjustment_map:, displacement_map:, lighting_map:)
     x_offset, y_offset, width, height = get_mask_bounding_box(@mask)
 
     main_image = @artwork.resize_to_fill(width, height)
@@ -112,10 +138,8 @@ class MockupGenerator
     main_image_with_offset = Magick::Image.new(@template.columns, @template.rows) { |image| image.background_color = 'transparent' }
     main_image_with_offset = main_image_with_offset.composite(main_image, x_offset, y_offset, Magick::OverCompositeOp)
 
-    displacement_map = Magick::Image.read('displacement_map.png').first
     main_image_with_offset = main_image_with_offset.displace(displacement_map, 20, 10)
 
-    lighting_map = Magick::Image.read('lighting_map.png').first
     main_image_with_offset = main_image_with_offset.composite(lighting_map, Magick::NorthWestGravity, Magick::HardLightCompositeOp)
 
     masked_template_area = extract_masked_area(@template, @mask)
@@ -124,11 +148,10 @@ class MockupGenerator
     threshold = Magick::QuantumRange * 0.5
     composite_operator = average_brightness < threshold ? Magick::SoftLightCompositeOp : Magick::MultiplyCompositeOp
 
-    adjustment_map = Magick::Image.read('adjustment_map.jpg').first
     main_image_with_offset = main_image_with_offset.composite(adjustment_map, Magick::NorthWestGravity, composite_operator)
 
     masked_image = main_image_with_offset.composite(@mask, Magick::NorthWestGravity, Magick::CopyAlphaCompositeOp)
     final_image = @template.composite(masked_image, Magick::NorthWestGravity, Magick::OverCompositeOp)
-    final_image.write('mockup.png')
+    final_image
   end
 end


### PR DESCRIPTION
## Summary
- return generated maps as in-memory images and composite them without writing temporary files
- add configurable output directory, basename, and optional intermediate asset persistence
- document the new configuration options and defaults in the README usage guide

## Testing
- ruby -c mockup_generator.rb

------
https://chatgpt.com/codex/tasks/task_e_68e28643ae1c8322b74ecf0ead9eae7e