### PR TITLE
Refine composer orchestration and migrate tests to Minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rmagick', '6.1.4'
+
+group :development, :test do
+  gem 'minitest', '~> 5.21'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,20 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.25.5)
+    observer (0.1.2)
+    pkg-config (1.6.4)
+    rmagick (6.1.4)
+      observer (~> 0.1)
+      pkg-config (~> 1.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  minitest (~> 5.21)
+  rmagick (= 6.1.4)
+
+BUNDLED WITH
+   2.6.7

--- a/lib/mockup_generator/compositors/adjustment_applicator.rb
+++ b/lib/mockup_generator/compositors/adjustment_applicator.rb
@@ -1,0 +1,24 @@
+require 'rmagick'
+require_relative 'mask_analyzer'
+
+module Compositors
+  class AdjustmentApplicator
+    def initialize(mask_analyzer: MaskAnalyzer.new, threshold: Magick::QuantumRange * 0.5)
+      @mask_analyzer = mask_analyzer
+      @threshold = threshold
+    end
+
+    def apply(base_image:, template:, mask:, adjustment_map:)
+      masked_area = @mask_analyzer.extract_area(template, mask)
+      avg_brightness = @mask_analyzer.average_brightness(masked_area)
+
+      composite_operator = avg_brightness < @threshold ? Magick::SoftLightCompositeOp : Magick::MultiplyCompositeOp
+
+      base_image.composite(adjustment_map, Magick::NorthWestGravity, composite_operator)
+    end
+
+    private
+
+    attr_reader :mask_analyzer
+  end
+end

--- a/lib/mockup_generator/compositors/final_composer.rb
+++ b/lib/mockup_generator/compositors/final_composer.rb
@@ -1,0 +1,37 @@
+require 'rmagick'
+require_relative 'main_image_builder'
+require_relative 'adjustment_applicator'
+require_relative 'mask_applicator'
+
+module Compositors
+  class FinalComposer
+    def initialize(main_image_builder: MainImageBuilder.new,
+                   adjustment_applicator: AdjustmentApplicator.new,
+                   mask_applicator: MaskApplicator.new)
+      @main_image_builder = main_image_builder
+      @adjustment_applicator = adjustment_applicator
+      @mask_applicator = mask_applicator
+    end
+
+    def compose(template:, mask:, artwork:, adjustment_map:, displacement_map:, lighting_map:)
+      main_image = @main_image_builder.build(
+        template: template,
+        mask: mask,
+        artwork: artwork,
+        displacement_map: displacement_map,
+        lighting_map: lighting_map
+      )
+
+      adjusted_image = @adjustment_applicator.apply(
+        base_image: main_image,
+        template: template,
+        mask: mask,
+        adjustment_map: adjustment_map
+      )
+
+      masked_image = @mask_applicator.apply(image: adjusted_image, mask: mask)
+
+      template.composite(masked_image, Magick::NorthWestGravity, Magick::OverCompositeOp)
+    end
+  end
+end

--- a/lib/mockup_generator/compositors/main_image_builder.rb
+++ b/lib/mockup_generator/compositors/main_image_builder.rb
@@ -1,0 +1,29 @@
+require 'rmagick'
+require_relative 'mask_analyzer'
+
+module Compositors
+  class MainImageBuilder
+    def initialize(mask_analyzer: MaskAnalyzer.new)
+      @mask_analyzer = mask_analyzer
+    end
+
+    def build(template:, mask:, artwork:, displacement_map:, lighting_map:)
+      x_offset, y_offset, width, height = @mask_analyzer.bounding_box(mask)
+
+      prepared_artwork = artwork.resize_to_fill(width, height)
+      prepared_artwork = prepared_artwork.border(1, 1, 'transparent')
+      prepared_artwork.alpha(Magick::RemoveAlphaChannel)
+
+      canvas = Magick::Image.new(template.columns, template.rows) do |image|
+        image.background_color = 'transparent'
+      end
+      canvas = canvas.composite(prepared_artwork, x_offset, y_offset, Magick::OverCompositeOp)
+      canvas = canvas.displace(displacement_map, 20, 10)
+      canvas.composite(lighting_map, Magick::NorthWestGravity, Magick::HardLightCompositeOp)
+    end
+
+    private
+
+    attr_reader :mask_analyzer
+  end
+end

--- a/lib/mockup_generator/compositors/mask_analyzer.rb
+++ b/lib/mockup_generator/compositors/mask_analyzer.rb
@@ -1,0 +1,42 @@
+require 'rmagick'
+
+module Compositors
+  class MaskAnalyzer
+    def bounding_box(mask)
+      trimmed = mask.trim
+
+      [trimmed.page.x, trimmed.page.y, trimmed.columns, trimmed.rows]
+    end
+
+    def extract_area(template, mask)
+      template_copy = template.copy
+      mask_copy = mask.copy
+
+      template_copy.alpha(Magick::ActivateAlphaChannel)
+
+      mask_copy = mask_copy.quantize(256, Magick::GRAYColorspace)
+      mask_copy.alpha(Magick::DeactivateAlphaChannel)
+
+      template_copy.composite(mask_copy, Magick::NorthWestGravity, Magick::CopyAlphaCompositeOp).trim
+    end
+
+    def average_brightness(image)
+      grayscale_image = image.quantize(256, Magick::GRAYColorspace)
+      pixels = grayscale_image.get_pixels(0, 0, grayscale_image.columns, grayscale_image.rows)
+
+      total_brightness = 0
+      total_pixels = 0
+
+      pixels.each do |pixel|
+        next if pixel.alpha == Magick::QuantumRange
+
+        total_brightness += pixel.red
+        total_pixels += 1
+      end
+
+      return Magick::QuantumRange / 2 if total_pixels.zero?
+
+      total_brightness / total_pixels
+    end
+  end
+end

--- a/lib/mockup_generator/compositors/mask_applicator.rb
+++ b/lib/mockup_generator/compositors/mask_applicator.rb
@@ -1,0 +1,9 @@
+require 'rmagick'
+
+module Compositors
+  class MaskApplicator
+    def apply(image:, mask:)
+      image.composite(mask, Magick::NorthWestGravity, Magick::CopyAlphaCompositeOp)
+    end
+  end
+end

--- a/lib/mockup_generator/loaders/template_loader.rb
+++ b/lib/mockup_generator/loaders/template_loader.rb
@@ -1,0 +1,19 @@
+require 'rmagick'
+
+module Loaders
+  class TemplateLoader
+    def load(template_path:, mask_path:, artwork_path:)
+      {
+        template: load_image(template_path),
+        mask: load_image(mask_path),
+        artwork: load_image(artwork_path)
+      }
+    end
+
+    private
+
+    def load_image(path)
+      Magick::Image.read(path).first
+    end
+  end
+end

--- a/lib/mockup_generator/maps/adjustment_generator.rb
+++ b/lib/mockup_generator/maps/adjustment_generator.rb
@@ -1,0 +1,10 @@
+require 'rmagick'
+
+module Maps
+  class AdjustmentGenerator
+    def generate(template:, mask:)
+      grayscale_mask = mask.quantize(256, Magick::GRAYColorspace)
+      template.composite(grayscale_mask, Magick::CenterGravity, Magick::DivideSrcCompositeOp)
+    end
+  end
+end

--- a/lib/mockup_generator/maps/displacement_generator.rb
+++ b/lib/mockup_generator/maps/displacement_generator.rb
@@ -1,0 +1,23 @@
+require 'rmagick'
+
+module Maps
+  class DisplacementGenerator
+    def generate(template:, mask:)
+      mask_normalized = mask.copy
+      mask_normalized.alpha(Magick::DeactivateAlphaChannel)
+      mask_normalized.colorspace = Magick::GRAYColorspace
+
+      template_normalized = template.copy
+      template_normalized.alpha(Magick::DeactivateAlphaChannel)
+      template_normalized.colorspace = Magick::GRAYColorspace
+
+      normalized_map = template_normalized.composite(mask_normalized, Magick::CenterGravity, Magick::CopyAlphaCompositeOp)
+
+      displacement_map = normalized_map.modulate(0.7, 1.0, 1.0)
+      displacement_map.background_color = 'grey50'
+      displacement_map.alpha(Magick::RemoveAlphaChannel)
+
+      displacement_map.blur_image(0, 10)
+    end
+  end
+end

--- a/lib/mockup_generator/maps/lighting_generator.rb
+++ b/lib/mockup_generator/maps/lighting_generator.rb
@@ -1,0 +1,17 @@
+require 'rmagick'
+
+module Maps
+  class LightingGenerator
+    def generate(template:, mask:)
+      normalized_map = template.composite(mask, Magick::CenterGravity, Magick::CopyAlphaCompositeOp)
+      normalized_map.alpha(Magick::DeactivateAlphaChannel)
+
+      lighting_map = normalized_map.modulate(0.7, 1.0, 1.0)
+      lighting_map.background_color = 'grey50'
+      lighting_map.alpha(Magick::RemoveAlphaChannel)
+
+      grey_image = Magick::Image.new(lighting_map.columns, lighting_map.rows) { |img| img.background_color = 'grey50' }
+      lighting_map.composite(grey_image, Magick::CenterGravity, Magick::LightenCompositeOp)
+    end
+  end
+end

--- a/mockup_generator.rb
+++ b/mockup_generator.rb
@@ -1,14 +1,34 @@
 require 'rmagick'
 require 'fileutils'
 
+require_relative 'lib/mockup_generator/loaders/template_loader'
+require_relative 'lib/mockup_generator/maps/adjustment_generator'
+require_relative 'lib/mockup_generator/maps/displacement_generator'
+require_relative 'lib/mockup_generator/maps/lighting_generator'
+require_relative 'lib/mockup_generator/compositors/final_composer'
+
 class MockupGenerator
-  def initialize(template_path, mask_path, artwork_path, output_dir: nil, basename: nil, save_intermediate: false)
-    @template = Magick::Image.read(template_path).first
-    @mask = Magick::Image.read(mask_path).first
-    @artwork = Magick::Image.read(artwork_path).first
+  def initialize(template_path, mask_path, artwork_path, output_dir: nil, basename: nil, save_intermediate: false,
+                 template_loader: Loaders::TemplateLoader.new,
+                 adjustment_generator: Maps::AdjustmentGenerator.new,
+                 displacement_generator: Maps::DisplacementGenerator.new,
+                 lighting_generator: Maps::LightingGenerator.new,
+                 final_composer: Compositors::FinalComposer.new)
+    @template_path = template_path
+    @mask_path = mask_path
+    @artwork_path = artwork_path
+
     @output_dir = output_dir || Dir.pwd
     @basename = basename || 'mockup'
     @save_intermediate = save_intermediate
+
+    @template_loader = template_loader
+    @adjustment_generator = adjustment_generator
+    @displacement_generator = displacement_generator
+    @lighting_generator = lighting_generator
+    @final_composer = final_composer
+
+    load_images
   end
 
   def generate(output_dir: nil, basename: nil, save_intermediate: nil)
@@ -18,9 +38,13 @@ class MockupGenerator
 
     FileUtils.mkdir_p(effective_output_dir) unless Dir.exist?(effective_output_dir)
 
-    adjustment_map = generate_adjustment_map
-    displacement_map = generate_displacement_map
-    lighting_map = generate_lighting_map
+    template = @template.copy
+    mask = @mask.copy
+    artwork = @artwork.copy
+
+    adjustment_map = @adjustment_generator.generate(template: template.copy, mask: mask.copy)
+    displacement_map = @displacement_generator.generate(template: template.copy, mask: mask.copy)
+    lighting_map = @lighting_generator.generate(template: template.copy, mask: mask.copy)
 
     if effective_save_intermediate
       adjustment_map.write(File.join(effective_output_dir, "#{effective_basename}_adjustment_map.jpg"))
@@ -28,7 +52,10 @@ class MockupGenerator
       lighting_map.write(File.join(effective_output_dir, "#{effective_basename}_lighting_map.png"))
     end
 
-    final_image = generate_final_mockup(
+    final_image = @final_composer.compose(
+      template: template,
+      mask: mask,
+      artwork: artwork,
       adjustment_map: adjustment_map,
       displacement_map: displacement_map,
       lighting_map: lighting_map
@@ -41,117 +68,16 @@ class MockupGenerator
   end
 
   private
-  def extract_masked_area(template, mask)
-    template = template.copy
-    mask = mask.copy
 
-    template.alpha(Magick::ActivateAlphaChannel)
+  def load_images
+    images = @template_loader.load(
+      template_path: @template_path,
+      mask_path: @mask_path,
+      artwork_path: @artwork_path
+    )
 
-    mask = mask.quantize(256, Magick::GRAYColorspace)
-    mask.alpha(Magick::DeactivateAlphaChannel)
-
-    masked_area = template.composite(mask, Magick::NorthWestGravity, Magick::CopyAlphaCompositeOp)
-    masked_area.trim
-  end
-  
-  def calculate_average_brightness(image)
-    grayscale_image = image.quantize(256, Magick::GRAYColorspace)
-  
-    pixels = grayscale_image.get_pixels(0, 0, grayscale_image.columns, grayscale_image.rows)
-  
-    total_brightness = 0
-    total_pixels = 0
-  
-    pixels.each do |pixel|
-      next if pixel.alpha == Magick::QuantumRange
-
-      brightness = pixel.red
-  
-      total_brightness += brightness
-      total_pixels += 1
-    end
-  
-    if total_pixels == 0
-      Magick::QuantumRange / 2
-    else 
-      total_brightness / total_pixels
-    end
-  end
-
-  def generate_adjustment_map
-    grayscale_mask = @mask.quantize(256, Magick::GRAYColorspace)
-    adjustment_map = @template.composite(grayscale_mask, Magick::CenterGravity, Magick::DivideSrcCompositeOp)
-    adjustment_map
-  end
-
-  def generate_displacement_map
-    mask_normalized = @mask.copy
-    mask_normalized.alpha(Magick::DeactivateAlphaChannel)
-    mask_normalized.colorspace = Magick::GRAYColorspace
-  
-    template_normalized = @template.copy
-    template_normalized.alpha(Magick::DeactivateAlphaChannel)
-    template_normalized.colorspace = Magick::GRAYColorspace
-  
-    normalized_map = template_normalized.composite(mask_normalized, Magick::CenterGravity, Magick::CopyAlphaCompositeOp)
-  
-    displacement_map = normalized_map.modulate(0.7, 1.0, 1.0)
-    displacement_map.background_color = 'grey50'
-    displacement_map.alpha(Magick::RemoveAlphaChannel)
-  
-    displacement_map = displacement_map.blur_image(0, 10)
-
-    displacement_map
-  end
-
-  def generate_lighting_map
-    normalized_map = @template.composite(@mask, Magick::CenterGravity, Magick::CopyAlphaCompositeOp)
-    normalized_map.alpha(Magick::DeactivateAlphaChannel)
-    
-    lighting_map = normalized_map.modulate(0.7, 1.0, 1.0)
-    lighting_map.background_color = 'grey50'
-    lighting_map.alpha(Magick::RemoveAlphaChannel)
-    
-    grey_image = Magick::Image.new(lighting_map.columns, lighting_map.rows) { |img| img.background_color = 'grey50' }
-    lighting_map = lighting_map.composite(grey_image, Magick::CenterGravity, Magick::LightenCompositeOp)
-    lighting_map
-  end
-
-  def get_mask_bounding_box(mask)
-    trimmed = mask.trim
-
-    x_offset = trimmed.page.x
-    y_offset = trimmed.page.y
-    width = trimmed.columns
-    height = trimmed.rows
-
-    return [x_offset, y_offset, width, height]
-  end
-
-  def generate_final_mockup(adjustment_map:, displacement_map:, lighting_map:)
-    x_offset, y_offset, width, height = get_mask_bounding_box(@mask)
-
-    main_image = @artwork.resize_to_fill(width, height)
-    main_image = main_image.border(1, 1, 'transparent')
-    main_image.alpha(Magick::RemoveAlphaChannel)
-
-    main_image_with_offset = Magick::Image.new(@template.columns, @template.rows) { |image| image.background_color = 'transparent' }
-    main_image_with_offset = main_image_with_offset.composite(main_image, x_offset, y_offset, Magick::OverCompositeOp)
-
-    main_image_with_offset = main_image_with_offset.displace(displacement_map, 20, 10)
-
-    main_image_with_offset = main_image_with_offset.composite(lighting_map, Magick::NorthWestGravity, Magick::HardLightCompositeOp)
-
-    masked_template_area = extract_masked_area(@template, @mask)
-    average_brightness = calculate_average_brightness(masked_template_area)
-
-    threshold = Magick::QuantumRange * 0.5
-    composite_operator = average_brightness < threshold ? Magick::SoftLightCompositeOp : Magick::MultiplyCompositeOp
-
-    main_image_with_offset = main_image_with_offset.composite(adjustment_map, Magick::NorthWestGravity, composite_operator)
-
-    masked_image = main_image_with_offset.composite(@mask, Magick::NorthWestGravity, Magick::CopyAlphaCompositeOp)
-    final_image = @template.composite(masked_image, Magick::NorthWestGravity, Magick::OverCompositeOp)
-    final_image
+    @template = images[:template]
+    @mask = images[:mask]
+    @artwork = images[:artwork]
   end
 end

--- a/test/adjustment_applicator_test.rb
+++ b/test/adjustment_applicator_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+class StubMaskAnalyzer
+  def initialize(average_brightness)
+    @average_brightness = average_brightness
+  end
+
+  def extract_area(_template, _mask)
+    :area
+  end
+
+  def average_brightness(_image)
+    @average_brightness
+  end
+end
+
+class RecordingImage
+  attr_reader :composite_calls
+
+  def initialize
+    @composite_calls = []
+  end
+
+  def composite(map, gravity, operator)
+    @composite_calls << { map: map, gravity: gravity, operator: operator }
+    self
+  end
+end
+
+class AdjustmentApplicatorTest < Minitest::Test
+  def setup
+    @adjustment_map = Magick::Image.new(2, 2)
+    @threshold = Magick::QuantumRange * 0.5
+  end
+
+  def test_applies_soft_light_when_average_brightness_is_below_threshold
+    mask_analyzer = StubMaskAnalyzer.new(@threshold - 1)
+    applicator = Compositors::AdjustmentApplicator.new(mask_analyzer: mask_analyzer, threshold: @threshold)
+    base_image = RecordingImage.new
+
+    result = applicator.apply(
+      base_image: base_image,
+      template: :template,
+      mask: :mask,
+      adjustment_map: @adjustment_map
+    )
+
+    assert_equal base_image, result
+
+    call = base_image.composite_calls.last
+    assert_equal @adjustment_map, call[:map]
+    assert_equal Magick::NorthWestGravity, call[:gravity]
+    assert_equal Magick::SoftLightCompositeOp, call[:operator]
+  end
+
+  def test_applies_multiply_when_average_brightness_is_above_threshold
+    mask_analyzer = StubMaskAnalyzer.new(@threshold + 1)
+    applicator = Compositors::AdjustmentApplicator.new(mask_analyzer: mask_analyzer, threshold: @threshold)
+    base_image = RecordingImage.new
+
+    applicator.apply(
+      base_image: base_image,
+      template: :template,
+      mask: :mask,
+      adjustment_map: @adjustment_map
+    )
+
+    call = base_image.composite_calls.last
+    assert_equal Magick::MultiplyCompositeOp, call[:operator]
+  end
+end

--- a/test/adjustment_generator_test.rb
+++ b/test/adjustment_generator_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class AdjustmentGeneratorTest < Minitest::Test
+  def setup
+    @generator = Maps::AdjustmentGenerator.new
+    @template = Magick::Image.new(10, 10) { |img| img.background_color = 'gray50' }
+    @mask = Magick::Image.new(10, 10) { |img| img.background_color = 'white' }
+    draw = Magick::Draw.new
+    draw.fill('black')
+    draw.rectangle(2, 2, 7, 7)
+    draw.draw(@mask)
+  end
+
+  def test_generates_adjustment_map_with_template_dimensions
+    adjustment_map = @generator.generate(template: @template, mask: @mask)
+
+    assert_instance_of Magick::Image, adjustment_map
+    assert_equal @template.columns, adjustment_map.columns
+    assert_equal @template.rows, adjustment_map.rows
+  end
+end

--- a/test/displacement_generator_test.rb
+++ b/test/displacement_generator_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class DisplacementGeneratorTest < Minitest::Test
+  def setup
+    @generator = Maps::DisplacementGenerator.new
+    @template = Magick::Image.new(8, 8) { |img| img.background_color = 'gray60' }
+    @mask = Magick::Image.new(8, 8) { |img| img.background_color = 'white' }
+    draw = Magick::Draw.new
+    draw.fill('black')
+    draw.circle(4, 4, 4, 0)
+    draw.draw(@mask)
+  end
+
+  def test_produces_blurred_displacement_map_with_same_size
+    displacement_map = @generator.generate(template: @template, mask: @mask)
+
+    assert_instance_of Magick::Image, displacement_map
+    assert_equal @template.columns, displacement_map.columns
+    assert_equal @template.rows, displacement_map.rows
+  end
+end

--- a/test/final_composer_test.rb
+++ b/test/final_composer_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class FinalComposerTest < Minitest::Test
+  def setup
+    @composer = Compositors::FinalComposer.new
+    @template = Magick::Image.new(12, 12) { |img| img.background_color = 'gray40' }
+    @mask = Magick::Image.new(12, 12) { |img| img.background_color = 'transparent' }
+    draw = Magick::Draw.new
+    draw.fill('white')
+    draw.rectangle(3, 3, 8, 9)
+    draw.draw(@mask)
+    @artwork = Magick::Image.new(6, 8) { |img| img.background_color = 'blue' }
+    @adjustment_map = Maps::AdjustmentGenerator.new.generate(template: @template, mask: @mask)
+    @displacement_map = Maps::DisplacementGenerator.new.generate(template: @template, mask: @mask)
+    @lighting_map = Maps::LightingGenerator.new.generate(template: @template, mask: @mask)
+  end
+
+  def test_composes_final_image_using_generated_maps
+    final_image = @composer.compose(
+      template: @template,
+      mask: @mask,
+      artwork: @artwork,
+      adjustment_map: @adjustment_map,
+      displacement_map: @displacement_map,
+      lighting_map: @lighting_map
+    )
+
+    assert_instance_of Magick::Image, final_image
+    assert_equal @template.columns, final_image.columns
+    assert_equal @template.rows, final_image.rows
+  end
+end

--- a/test/lighting_generator_test.rb
+++ b/test/lighting_generator_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class LightingGeneratorTest < Minitest::Test
+  def setup
+    @generator = Maps::LightingGenerator.new
+    @template = Magick::Image.new(6, 6) { |img| img.background_color = 'gray70' }
+    @mask = Magick::Image.new(6, 6) { |img| img.background_color = 'white' }
+    draw = Magick::Draw.new
+    draw.fill('black')
+    draw.polygon(1, 1, 4, 1, 5, 5, 1, 4)
+    draw.draw(@mask)
+  end
+
+  def test_generates_lighting_map_with_template_dimensions
+    lighting_map = @generator.generate(template: @template, mask: @mask)
+
+    assert_instance_of Magick::Image, lighting_map
+    assert_equal @template.columns, lighting_map.columns
+    assert_equal @template.rows, lighting_map.rows
+  end
+end

--- a/test/main_image_builder_test.rb
+++ b/test/main_image_builder_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class MainImageBuilderTest < Minitest::Test
+  def setup
+    @mask = Magick::Image.new(12, 12) { |img| img.background_color = 'transparent' }
+    draw = Magick::Draw.new
+    draw.fill('white')
+    draw.rectangle(4, 2, 9, 10)
+    draw.draw(@mask)
+    @template = Magick::Image.new(12, 12) { |img| img.background_color = 'gray30' }
+    @artwork = Magick::Image.new(3, 4) { |img| img.background_color = 'red' }
+    @displacement_map = Magick::Image.new(12, 12) { |img| img.background_color = 'gray50' }
+    @lighting_map = Magick::Image.new(12, 12) { |img| img.background_color = 'gray60' }
+    @builder = Compositors::MainImageBuilder.new
+  end
+
+  def test_build_returns_canvas_matching_template_dimensions
+    canvas = @builder.build(
+      template: @template,
+      mask: @mask,
+      artwork: @artwork,
+      displacement_map: @displacement_map,
+      lighting_map: @lighting_map
+    )
+
+    assert_instance_of Magick::Image, canvas
+    assert_equal @template.columns, canvas.columns
+    assert_equal @template.rows, canvas.rows
+  end
+end

--- a/test/mask_analyzer_test.rb
+++ b/test/mask_analyzer_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class MaskAnalyzerTest < Minitest::Test
+  def setup
+    @analyzer = Compositors::MaskAnalyzer.new
+    @mask = Magick::Image.new(10, 10) { |img| img.background_color = 'transparent' }
+    draw = Magick::Draw.new
+    draw.fill('white')
+    draw.rectangle(2, 3, 7, 8)
+    draw.draw(@mask)
+    @template = Magick::Image.new(10, 10) { |img| img.background_color = 'gray20' }
+  end
+
+  def test_bounding_box_returns_coordinates_and_dimensions
+    x_offset, y_offset, width, height = @analyzer.bounding_box(@mask)
+
+    assert_equal 2, x_offset
+    assert_equal 3, y_offset
+    assert_equal 6, width
+    assert_equal 6, height
+  end
+
+  def test_extract_area_returns_trimmed_template_section
+    extracted = @analyzer.extract_area(@template, @mask)
+
+    assert_equal 6, extracted.columns
+    assert_equal 6, extracted.rows
+  end
+
+  def test_average_brightness_for_dark_image_is_below_midpoint
+    image = Magick::Image.new(2, 2) { |img| img.background_color = 'black' }
+
+    assert_operator @analyzer.average_brightness(image), :<=, Magick::QuantumRange / 2
+  end
+end

--- a/test/mask_applicator_test.rb
+++ b/test/mask_applicator_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class CompositeSpy
+  attr_reader :calls
+
+  def initialize
+    @calls = []
+  end
+
+  def composite(mask, gravity, operator)
+    @calls << { mask: mask, gravity: gravity, operator: operator }
+    :result
+  end
+end
+
+class MaskApplicatorTest < Minitest::Test
+  def test_apply_uses_copy_alpha_composite
+    base_image = CompositeSpy.new
+    mask = Magick::Image.new(2, 2)
+    applicator = Compositors::MaskApplicator.new
+
+    result = applicator.apply(image: base_image, mask: mask)
+
+    assert_equal :result, result
+    call = base_image.calls.last
+    assert_equal mask, call[:mask]
+    assert_equal Magick::NorthWestGravity, call[:gravity]
+    assert_equal Magick::CopyAlphaCompositeOp, call[:operator]
+  end
+end

--- a/test/mockup_generator_test.rb
+++ b/test/mockup_generator_test.rb
@@ -1,0 +1,126 @@
+require 'test_helper'
+
+class FakeImage
+  attr_reader :written_path
+
+  def write(path)
+    @written_path = path
+  end
+end
+
+class StubTemplateLoader
+  attr_reader :calls
+
+  def initialize(result)
+    @result = result
+    @calls = []
+  end
+
+  def load(args)
+    @calls << args
+    @result
+  end
+end
+
+class StubMapGenerator
+  attr_reader :calls
+
+  def initialize(result)
+    @result = result
+    @calls = []
+  end
+
+  def generate(args)
+    @calls << args
+    @result
+  end
+end
+
+class StubFinalComposer
+  attr_reader :calls
+
+  def initialize(result)
+    @result = result
+    @calls = []
+  end
+
+  def compose(args)
+    @calls << args
+    @result
+  end
+end
+
+class MockupGeneratorTest < Minitest::Test
+  def setup
+    @template = Magick::Image.new(4, 4) { |img| img.background_color = 'gray50' }
+    @mask = Magick::Image.new(4, 4) { |img| img.background_color = 'white' }
+    @artwork = Magick::Image.new(4, 4) { |img| img.background_color = 'red' }
+
+    @adjustment_map = Magick::Image.new(4, 4)
+    @displacement_map = Magick::Image.new(4, 4)
+    @lighting_map = Magick::Image.new(4, 4)
+
+    @final_image = FakeImage.new
+
+    @template_loader = StubTemplateLoader.new(template: @template, mask: @mask, artwork: @artwork)
+    @adjustment_generator = StubMapGenerator.new(@adjustment_map)
+    @displacement_generator = StubMapGenerator.new(@displacement_map)
+    @lighting_generator = StubMapGenerator.new(@lighting_map)
+    @final_composer = StubFinalComposer.new(@final_image)
+
+    @output_dir = Dir.mktmpdir
+  end
+
+  def teardown
+    FileUtils.remove_entry(@output_dir)
+  end
+
+  def test_orchestrates_dependencies_to_generate_mockup
+    generator = MockupGenerator.new(
+      'template.png',
+      'mask.png',
+      'artwork.png',
+      output_dir: @output_dir,
+      basename: 'result',
+      save_intermediate: false,
+      template_loader: @template_loader,
+      adjustment_generator: @adjustment_generator,
+      displacement_generator: @displacement_generator,
+      lighting_generator: @lighting_generator,
+      final_composer: @final_composer
+    )
+
+    result = generator.generate
+
+    assert_equal @final_image, result
+    assert_equal File.join(@output_dir, 'result.png'), @final_image.written_path
+
+    load_call = @template_loader.calls.first
+    assert_equal 'template.png', load_call[:template_path]
+    assert_equal 'mask.png', load_call[:mask_path]
+    assert_equal 'artwork.png', load_call[:artwork_path]
+
+    @adjustment_generator.calls.each do |call|
+      assert_kind_of Magick::Image, call[:template]
+      assert_kind_of Magick::Image, call[:mask]
+    end
+
+    @displacement_generator.calls.each do |call|
+      assert_kind_of Magick::Image, call[:template]
+      assert_kind_of Magick::Image, call[:mask]
+    end
+
+    @lighting_generator.calls.each do |call|
+      assert_kind_of Magick::Image, call[:template]
+      assert_kind_of Magick::Image, call[:mask]
+    end
+
+    compose_call = @final_composer.calls.first
+    assert_kind_of Magick::Image, compose_call[:template]
+    assert_kind_of Magick::Image, compose_call[:mask]
+    assert_kind_of Magick::Image, compose_call[:artwork]
+    assert_equal @adjustment_map, compose_call[:adjustment_map]
+    assert_equal @displacement_map, compose_call[:displacement_map]
+    assert_equal @lighting_map, compose_call[:lighting_map]
+  end
+end

--- a/test/template_loader_test.rb
+++ b/test/template_loader_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+require 'tempfile'
+
+class TemplateLoaderTest < Minitest::Test
+  def setup
+    @loader = Loaders::TemplateLoader.new
+    @template_file = Tempfile.new(['template', '.png'])
+    @mask_file = Tempfile.new(['mask', '.png'])
+    @artwork_file = Tempfile.new(['artwork', '.png'])
+
+    Magick::Image.new(5, 5) { |img| img.background_color = 'white' }.write(@template_file.path)
+    Magick::Image.new(5, 5) { |img| img.background_color = 'black' }.write(@mask_file.path)
+    Magick::Image.new(5, 5) { |img| img.background_color = 'red' }.write(@artwork_file.path)
+  end
+
+  def teardown
+    [@template_file, @mask_file, @artwork_file].each do |file|
+      file.close
+      file.unlink
+    end
+  end
+
+  def test_loads_template_mask_and_artwork
+    result = @loader.load(
+      template_path: @template_file.path,
+      mask_path: @mask_file.path,
+      artwork_path: @artwork_file.path
+    )
+
+    assert_instance_of Magick::Image, result[:template]
+    assert_instance_of Magick::Image, result[:mask]
+    assert_instance_of Magick::Image, result[:artwork]
+
+    assert_equal 5, result[:template].columns
+    assert_equal 5, result[:mask].rows
+    assert_equal 5, result[:artwork].columns
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,18 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'tmpdir'
+require 'fileutils'
+require 'rmagick'
+
+$LOAD_PATH.unshift(File.expand_path('..', __dir__))
+
+require 'mockup_generator'
+require 'lib/mockup_generator/loaders/template_loader'
+require 'lib/mockup_generator/maps/adjustment_generator'
+require 'lib/mockup_generator/maps/displacement_generator'
+require 'lib/mockup_generator/maps/lighting_generator'
+require 'lib/mockup_generator/compositors/final_composer'
+require 'lib/mockup_generator/compositors/main_image_builder'
+require 'lib/mockup_generator/compositors/adjustment_applicator'
+require 'lib/mockup_generator/compositors/mask_applicator'
+require 'lib/mockup_generator/compositors/mask_analyzer'


### PR DESCRIPTION
## Summary
- pin rmagick 6.1.4 and add minitest in the development/test group
- split `Compositors::FinalComposer` responsibilities into dedicated builder, adjustment, and mask helpers
- replace the RSpec suite with Minitest coverage for the loader, generators, composer, and orchestrator

## Testing
- ruby -Itest -e 'Dir["test/**/*_test.rb"].sort.each { |f| require File.expand_path(f) }'


------
https://chatgpt.com/codex/tasks/task_e_68e28746ce488322b7473a27d932b7f1